### PR TITLE
Parse (closed) choice args on the command line

### DIFF
--- a/draccus/argparsing.py
+++ b/draccus/argparsing.py
@@ -41,9 +41,10 @@ class ArgumentParser(Generic[T]):
         kwargs["formatter_class"] = formatter_class
         if "exit_on_error" in kwargs:
             # only available in python 3.9+, remove arg if not supported
-            # behavior was functionally True before 3.9
-            if not kwargs["exit_on_error"] and sys.version_info < (3, 9):
-                warnings.warn("ArgumentParser exit_on_error is only available in python 3.9+, removing argument")
+            if sys.version_info < (3, 9):
+                # behavior was functionally True before 3.9
+                if not kwargs["exit_on_error"]:
+                    warnings.warn("ArgumentParser exit_on_error is only available in python 3.9+, removing argument")
                 del kwargs["exit_on_error"]
 
         self.parser = SuppressingArgumentParser(*args, **kwargs)

--- a/draccus/argparsing.py
+++ b/draccus/argparsing.py
@@ -37,8 +37,15 @@ class ArgumentParser(Generic[T]):
         **kwargs,
     ):
         """Creates an ArgumentParser instance."""
+        kwargs = kwargs.copy()
         kwargs["formatter_class"] = formatter_class
-        # self.parser = argparse.ArgumentParser(*args, **kwargs)
+        if "exit_on_error" in kwargs:
+            # only available in python 3.9+, remove arg if not supported
+            # behavior was functionally True before 3.9
+            if not kwargs["exit_on_error"] and sys.version_info < (3, 9):
+                warnings.warn("ArgumentParser exit_on_error is only available in python 3.9+, removing argument")
+                del kwargs["exit_on_error"]
+
         self.parser = SuppressingArgumentParser(*args, **kwargs)
 
         # constructor arguments for the dataclass instances.

--- a/draccus/argparsing.py
+++ b/draccus/argparsing.py
@@ -19,6 +19,7 @@ from draccus.help_formatter import SimpleHelpFormatter
 from draccus.parsers import decoding
 from draccus.utils import Dataclass, PyrallisException
 from draccus.wrappers import DataclassWrapper
+from draccus.wrappers.suppressing_argparse import SuppressingArgumentParser
 
 
 logger = getLogger(__name__)
@@ -37,7 +38,8 @@ class ArgumentParser(Generic[T]):
     ):
         """Creates an ArgumentParser instance."""
         kwargs["formatter_class"] = formatter_class
-        self.parser = argparse.ArgumentParser(*args, **kwargs)
+        # self.parser = argparse.ArgumentParser(*args, **kwargs)
+        self.parser = SuppressingArgumentParser(*args, **kwargs)
 
         # constructor arguments for the dataclass instances.
         # (a Dict[dest, [attribute, value]])
@@ -143,9 +145,20 @@ def parse(
     config_class: Type[T],
     config_path: Optional[Union[Path, str]] = None,
     args: Optional[Sequence[str]] = None,
+    prog: Optional[str] = None,
     exit_on_error: bool = True,
 ) -> T:
-    parser = ArgumentParser(config_class=config_class, config_path=config_path, exit_on_error=exit_on_error)
+    """
+    Parses the command line arguments and returns an instance of the config class.
+
+    Args:
+        config_class: The config class to parse.
+        config_path: The path to the config file to parse.
+        args: The command line arguments to parse. If None, defaults to sys.argv[1:].
+        prog: The name of the program (for the help message).
+        exit_on_error: Whether to exit if an error occurs.
+    """
+    parser = ArgumentParser(config_class=config_class, config_path=config_path, exit_on_error=exit_on_error, prog=prog)
     return parser.parse_args(args)
 
 

--- a/draccus/argparsing.py
+++ b/draccus/argparsing.py
@@ -143,8 +143,9 @@ def parse(
     config_class: Type[T],
     config_path: Optional[Union[Path, str]] = None,
     args: Optional[Sequence[str]] = None,
+    exit_on_error: bool = True,
 ) -> T:
-    parser = ArgumentParser(config_class=config_class, config_path=config_path)
+    parser = ArgumentParser(config_class=config_class, config_path=config_path, exit_on_error=exit_on_error)
     return parser.parse_args(args)
 
 

--- a/draccus/choice_types.py
+++ b/draccus/choice_types.py
@@ -75,7 +75,12 @@ class ChoiceType(Protocol):
 
 
 class ChoiceRegistry(ChoiceType):
-    _choice_registry: ClassVar[Dict[str, Type]] = {}
+    _choice_registry: ClassVar[Dict[str, Any]]
+
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+        if not hasattr(cls, "_choice_registry"):
+            cls._choice_registry: ClassVar[Dict[str, Any]] = {}
 
     @classmethod
     def get_choice_class(cls, name: str) -> Any:

--- a/draccus/parsers/decoding.py
+++ b/draccus/parsers/decoding.py
@@ -16,6 +16,7 @@ from draccus.utils import (
     format_error,
     get_type_arguments,
     has_generic_arg,
+    is_choice_type,
     is_dict,
     is_enum,
     is_list,
@@ -171,7 +172,7 @@ def get_decoding_fn(cls: Type[T]) -> Callable[[Any], T]:
         else:
             return cached_func.func
 
-    elif inspect.isclass(cls) and issubclass(cls, ChoiceType):
+    elif is_choice_type(cls):
         return partial(decode_choice_class, cls)
 
     elif is_dataclass(cls):

--- a/draccus/parsers/encoding.py
+++ b/draccus/parsers/encoding.py
@@ -78,7 +78,7 @@ def encode(obj: Any) -> Any:
         raise e
 
 
-def encode_dataclass(obj):
+def encode_dataclass(obj: Any):
     d: Dict[str, Any] = dict()
     for field in fields(obj):
         value = getattr(obj, field.name)

--- a/draccus/utils.py
+++ b/draccus/utils.py
@@ -322,6 +322,12 @@ def has_generic_arg(args):
     return False
 
 
+def is_choice_type(cls) -> bool:
+    from draccus.choice_types import ChoiceType
+
+    return inspect.isclass(cls) and issubclass(cls, ChoiceType)
+
+
 CONFIG_ARG = "config_path"
 
 if __name__ == "__main__":

--- a/draccus/wrappers/choice_wrapper.py
+++ b/draccus/wrappers/choice_wrapper.py
@@ -1,0 +1,138 @@
+import dataclasses
+from argparse import _ActionsContainer, _ArgumentGroup
+from dataclasses import Field
+from functools import cached_property
+from typing import Dict, Optional, Type
+
+from ..choice_types import CHOICE_TYPE_KEY, ChoiceType
+from ..parsers.decoding import has_custom_decoder
+from . import docstring
+from .wrapper import Wrapper
+
+
+class ChoiceWrapper(Wrapper):
+    def __init__(
+        self,
+        choice_type: Type[ChoiceType],
+        name: Optional[str] = None,
+        # default: Optional[Union[Dataclass, Dict]] = None,
+        parent: Optional[Wrapper] = None,
+        _field: Optional[dataclasses.Field] = None,
+    ):
+        self.choice_type = choice_type
+        self._name = name
+        # TODO: need to use the default
+        # self.default = default
+        self._parent = parent
+        self._field = _field
+
+        self._required: bool = False
+        self._explicit: bool = False
+
+    @property
+    def title(self) -> str:
+        title = self.choice_type.__qualname__
+        if self.dest is not None:  # Show name if exists
+            title += f" ['{self.dest}']"
+        return title
+
+    @property
+    def parent(self) -> Optional["Wrapper"]:
+        return self._parent
+
+    @property
+    def description(self) -> str:
+        if self.parent and self._field:
+            doc = docstring.get_attribute_docstring(self.parent.type, self._field.name)
+            if doc is not None:
+                if doc.docstring_below:
+                    return doc.docstring_below
+                elif doc.comment_above:
+                    return doc.comment_above
+                elif doc.comment_inline:
+                    return doc.comment_inline
+        class_doc = self.choice_type.__doc__ or ""
+        if class_doc.startswith(f"{self.choice_type.__name__}("):
+            return ""  # The base dataclass doc looks confusing, remove it
+        return class_doc
+
+    def register_actions(self, parser: _ActionsContainer) -> None:
+        # group = parser.add_argument_group(title=self.title, description=self.description)
+        group = _SuppressingArgumentGroup(parser, title=self.title, description=self.description)
+
+        children = self._children
+
+        # register the type argument. If closed, it's a choice between the known types, otherwise just a string with a fancy desc
+        dest = self.dest
+        if dest is None:
+            arg_name = CHOICE_TYPE_KEY
+        else:
+            arg_name = f"{dest}.{CHOICE_TYPE_KEY}"
+
+        if self.choice_type.is_open_choice():
+            group.add_argument(
+                f"--{arg_name}", help=f"Which type of {self.title} to use. Known types: {', '.join(children.keys())}"
+            )
+        else:
+            group.add_argument(
+                f"--{arg_name}", choices=list(children.keys()), help=f"Which type of {self.title} to use"
+            )
+
+        for child in self._children.values():
+            # TODO: need to suppress conflicts among the choices
+            child.register_actions(group)
+
+    @cached_property
+    def _children(self) -> Dict[str, Wrapper]:
+        from .dataclass_wrapper import DataclassWrapper
+
+        def _wrap_child(child: Type) -> Wrapper:
+            if not dataclasses.is_dataclass(child):
+                raise ValueError(f"Expected a dataclass, got {child}")
+            if has_custom_decoder(child):
+                raise ValueError(f"Cannot use class with custom decoder as choice type: {child}")
+
+            # because we "substitute" the choice type for the child, we need to make sure that
+            # the child's parent is the same as the choice type's parent
+            return DataclassWrapper(child, parent=self.parent, _field=self._field)
+
+        return {name: _wrap_child(child) for name, child in self.choice_type.get_known_choices().items()}
+
+    @property
+    def required(self) -> bool:
+        return self._required
+
+    @required.setter
+    def required(self, value: bool):
+        self._required = value
+        for child_wrapper in self._children.values():
+            child_wrapper.required = value
+
+    @property
+    def name(self) -> str:
+        return self._name or self.choice_type.__name__
+
+    @property
+    def field(self) -> Optional[Field]:
+        return self._field
+
+    @property
+    def type(self) -> Type:
+        return self.choice_type
+
+
+class _SuppressingArgumentGroup(_ArgumentGroup):
+    def add_argument(self, *args, **kwargs):
+        kwargs["conflict_handler"] = "ignore"
+        return super().add_argument(*args, **kwargs)
+
+    def add_argument_group(self, *args, **kwargs):
+        group = _SuppressingArgumentGroup(self, *args, **kwargs)
+        self._action_groups.append(group)
+        return group
+
+    def add_mutually_exclusive_group(self, *args, **kwargs):
+        raise NotImplementedError("Mutually exclusive groups are not supported for choice types")
+
+    def _handle_conflict_ignore(self, action, conflicting_actions):
+        pass

--- a/draccus/wrappers/choice_wrapper.py
+++ b/draccus/wrappers/choice_wrapper.py
@@ -128,7 +128,7 @@ class ChoiceWrapper(Wrapper):
 
 class _SuppressingArgumentGroup(_ArgumentGroup):
     def __init__(self, container, *args, **kwargs):
-        kwargs = {**kwargs, "conflict_handler": "ignore"}
+        kwargs = {**kwargs, "conflict_handler": "resolve"}
         super().__init__(container, *args, **kwargs)
 
     def add_argument(self, *args, **kwargs):

--- a/draccus/wrappers/choice_wrapper.py
+++ b/draccus/wrappers/choice_wrapper.py
@@ -71,11 +71,16 @@ class ChoiceWrapper(Wrapper):
 
         if self.choice_type.is_open_choice():
             group.add_argument(
-                f"--{arg_name}", help=f"Which type of {self.title} to use. Known types: {', '.join(children.keys())}"
+                f"--{arg_name}",
+                help=f"Which type of {self.title} to use. Known types: {', '.join(children.keys())}",
+                required=self.required,
             )
         else:
             group.add_argument(
-                f"--{arg_name}", choices=list(children.keys()), help=f"Which type of {self.title} to use"
+                f"--{arg_name}",
+                choices=list(children.keys()),
+                help=f"Which type of {self.title} to use",
+                required=self.required,
             )
 
         for child in self._children.values():
@@ -94,7 +99,7 @@ class ChoiceWrapper(Wrapper):
 
             # because we "substitute" the choice type for the child, we need to make sure that
             # the child's parent is the same as the choice type's parent
-            return DataclassWrapper(child, parent=self.parent, _field=self._field)
+            return DataclassWrapper(child, parent=self.parent, _field=self._field, name=self.name)
 
         return {name: _wrap_child(child) for name, child in self.choice_type.get_known_choices().items()}
 
@@ -122,8 +127,11 @@ class ChoiceWrapper(Wrapper):
 
 
 class _SuppressingArgumentGroup(_ArgumentGroup):
+    def __init__(self, container, *args, **kwargs):
+        kwargs = {**kwargs, "conflict_handler": "ignore"}
+        super().__init__(container, *args, **kwargs)
+
     def add_argument(self, *args, **kwargs):
-        kwargs["conflict_handler"] = "ignore"
         return super().add_argument(*args, **kwargs)
 
     def add_argument_group(self, *args, **kwargs):

--- a/draccus/wrappers/dataclass_wrapper.py
+++ b/draccus/wrappers/dataclass_wrapper.py
@@ -7,9 +7,11 @@ from typing import Dict, List, Optional, Type, Union, cast
 from draccus.utils import Dataclass, DataclassType
 
 from .. import utils
+from ..choice_types import ChoiceType
 
 # from ..parsers.decoding import get_decoding_fn, has_custom_decoder
 from . import docstring
+from .choice_wrapper import ChoiceWrapper
 from .field_wrapper import FieldWrapper
 from .wrapper import Wrapper
 
@@ -33,7 +35,6 @@ class DataclassWrapper(Wrapper[Type[Dataclass]]):
 
         self._required: bool = False
         self._explicit: bool = False
-        self._dest: str = ""
         self._children: List[Wrapper] = []
         self._parent = parent
         # the field of the parent, which contains this child dataclass.
@@ -152,6 +153,8 @@ def _wrap_field(parent: Optional[Wrapper], field: dataclasses.Field) -> Optional
     #     field_wrapper = field_wrapper_class(field, parent=self, prefix=self.prefix)
     #     logger.debug(f"wrapped field at {field_wrapper.dest} has a default value of {field_wrapper.default}")
     #     return field_wrapper
+    elif utils.is_choice_type(field.type):
+        return ChoiceWrapper(cast(Type[ChoiceType], field.type), field.name, parent=parent, _field=field)
 
     elif utils.is_tuple_or_list_of_dataclasses(field.type):
         raise NotImplementedError(

--- a/draccus/wrappers/field_wrapper.py
+++ b/draccus/wrappers/field_wrapper.py
@@ -296,7 +296,7 @@ class FieldWrapper(Wrapper[dataclasses.Field]):
     def parent(self):
         return self._parent
 
-    def register_actions(self, parser: _ActionsContainer) -> None:
+    def add_action(self, parser: _ActionsContainer) -> None:
         logger.debug(f"Arg options for field '{self.name}': {self.arg_options}")
         parser.add_argument(*self.option_strings, **self.arg_options)
 

--- a/draccus/wrappers/suppressing_argparse.py
+++ b/draccus/wrappers/suppressing_argparse.py
@@ -1,0 +1,51 @@
+from argparse import ArgumentParser, _ArgumentGroup
+
+
+class SuppressingArgumentParser(ArgumentParser):
+    """
+    ArgumentParser that has a slightly exotic method of handling conflicts.
+    We don't want to raise an error if we have a conflict, we just want to ignore it.
+    Ideally we'd have a way to say "take the first one", but that doesn't exist and
+    can't be easily retrofitted. So we take the last one, but keep the
+    old ones for the help message by leaving them in _group_actions but not in _actions.
+    """
+
+    def __init__(self, *args, **kwargs):
+        kwargs = {**kwargs, "conflict_handler": "ignore"}
+        super().__init__(*args, **kwargs)
+
+    def add_argument_group(self, *args, **kwargs):
+        group = _SuppressingArgumentGroup(self, *args, **kwargs)
+        self._action_groups.append(group)
+        return group
+
+    def _handle_conflict_ignore(self, action, conflicting_actions):
+
+        # remove all conflicting options
+        for option_string, action in conflicting_actions:
+            action.container._remove_action(action)
+
+
+class _SuppressingArgumentGroup(_ArgumentGroup):
+    def __init__(self, container, *args, **kwargs):
+        kwargs = {**kwargs, "conflict_handler": "ignore"}
+        super().__init__(container, *args, **kwargs)
+
+    def add_argument(self, *args, **kwargs):
+        return super().add_argument(*args, **kwargs)
+
+    def add_argument_group(self, *args, **kwargs):
+        raise NotImplementedError("It's a bad idea to nest argument groups. argparse ignores them for help")
+
+    def add_mutually_exclusive_group(self, *args, **kwargs):
+        raise NotImplementedError("It's a bad idea to nest argument groups. argparse ignores them for help")
+
+    def _remove_action(self, action):
+        self._actions.remove(action)
+        # don't remove from _group_actions, so that we can still show the old ones in the help message
+
+    def _handle_conflict_ignore(self, action, conflicting_actions):
+
+        # remove all conflicting options
+        for option_string, action in conflicting_actions:
+            action.container._remove_action(action)

--- a/draccus/wrappers/wrapper.py
+++ b/draccus/wrappers/wrapper.py
@@ -1,7 +1,7 @@
 """Abstract Wrapper base-class for the FieldWrapper and DataclassWrapper."""
 import abc
+import argparse
 from abc import ABC, abstractmethod
-from argparse import _ActionsContainer
 from dataclasses import Field
 from typing import Generic, List, Optional, Type
 
@@ -53,10 +53,6 @@ class Wrapper(Generic[T], ABC):
     def parent(self) -> Optional["Wrapper"]:
         pass
 
-    @abstractmethod
-    def register_actions(self, parser: _ActionsContainer) -> None:
-        pass
-
     @property
     @abstractmethod
     def required(self) -> bool:
@@ -75,4 +71,12 @@ class Wrapper(Generic[T], ABC):
     @property
     @abstractmethod
     def type(self) -> Type:
+        pass
+
+
+class AggregateWrapper(Wrapper[T]):
+    """Wrapper for types that have fields (i.e. Dataclasses and Choices)."""
+
+    @abstractmethod
+    def register_actions(self, parser: argparse.ArgumentParser) -> None:
         pass

--- a/draccus/wrappers/wrapper.py
+++ b/draccus/wrappers/wrapper.py
@@ -21,7 +21,9 @@ class Wrapper(Generic[T], ABC):
         lineage_names: List[str] = [w.name for w in self.lineage()]
         if lineage_names[-1] is None:  # root usually won't have a name
             lineage_names = lineage_names[:-1]
-        return ".".join(reversed([self.name] + lineage_names))
+
+        r = list(reversed([self.name] + lineage_names))
+        return ".".join(r)
 
     def lineage(self) -> List["Wrapper"]:
         lineage: List[Wrapper] = []

--- a/tests/test_argparse_choice_types.py
+++ b/tests/test_argparse_choice_types.py
@@ -22,7 +22,7 @@ class Adult(Person):
 
 @dataclasses.dataclass
 class Child(Person):
-    favorite_toy: str
+    favorite_toy: str  # Child's favorite toy
 
 
 Person.register_subclass("adult", Adult)
@@ -50,6 +50,12 @@ def test_choice_registry_argparse():
         Something.setup("--person.name hi")
 
 
-def test_choice_registry_encode():
-    assert draccus.encode(Adult("bob", 10)) == {"type": "adult", "name": "bob", "age": 10}
-    assert draccus.encode(Child("bob", "truck")) == {"type": "child", "name": "bob", "favorite_toy": "truck"}
+# @dataclasses.dataclass
+# class Something(TestSetup):
+#     person: Person = Adult("bob", 10)
+#
+# def test_choice_registry_examine_help():
+#     assert Something.get_help_text() == """\
+# usage: pytest [-h] [--person.type {adult,child}] [--person.name str]
+#                 [--person.age int] [--person.favorite_toy str]
+#                 """

--- a/tests/test_argparse_choice_types.py
+++ b/tests/test_argparse_choice_types.py
@@ -1,0 +1,55 @@
+import dataclasses
+from argparse import ArgumentError
+
+import pytest
+
+import draccus
+from draccus import ParsingError
+from draccus.choice_types import ChoiceRegistry
+
+from .testutils import TestSetup
+
+
+@dataclasses.dataclass
+class Person(ChoiceRegistry):
+    name: str
+
+
+@dataclasses.dataclass
+class Adult(Person):
+    age: int
+
+
+@dataclasses.dataclass
+class Child(Person):
+    favorite_toy: str
+
+
+Person.register_subclass("adult", Adult)
+Person.register_subclass("child", Child)
+
+
+def test_choice_registry_argparse():
+    @dataclasses.dataclass
+    class Something(TestSetup):
+        person: Person = Adult("bob", 10)
+
+    s = Something.setup("")
+    assert s.person == Adult("bob", 10)
+
+    s = Something.setup("--person.type child --person.name bob --person.favorite_toy truck")
+    assert s.person == Child("bob", "truck")
+
+    with pytest.raises(ArgumentError):
+        Something.setup("--person.type baby --person.name bob")
+
+    with pytest.raises(ParsingError):
+        Something.setup("--person.type adult --person.name bob --person.age 10 --person.favorite_toy truck")
+
+    with pytest.raises(ParsingError):
+        Something.setup("--person.name hi")
+
+
+def test_choice_registry_encode():
+    assert draccus.encode(Adult("bob", 10)) == {"type": "adult", "name": "bob", "age": 10}
+    assert draccus.encode(Child("bob", "truck")) == {"type": "child", "name": "bob", "favorite_toy": "truck"}

--- a/tests/test_argparse_choice_types.py
+++ b/tests/test_argparse_choice_types.py
@@ -12,7 +12,7 @@ from .testutils import TestSetup
 
 @dataclasses.dataclass
 class Person(ChoiceRegistry):
-    name: str
+    name: str  # Person's name
 
 
 @dataclasses.dataclass
@@ -50,12 +50,16 @@ def test_choice_registry_argparse():
         Something.setup("--person.name hi")
 
 
-# @dataclasses.dataclass
-# class Something(TestSetup):
-#     person: Person = Adult("bob", 10)
-#
-# def test_choice_registry_examine_help():
-#     assert Something.get_help_text() == """\
-# usage: pytest [-h] [--person.type {adult,child}] [--person.name str]
-#                 [--person.age int] [--person.favorite_toy str]
-#                 """
+@dataclasses.dataclass
+class Something(TestSetup):
+    person: Person = Adult("bob", 10)
+
+
+def test_choice_registry_examine_help():
+    assert (
+        Something.get_help_text()
+        == """\
+usage: pytest [-h] [--person.type {adult,child}] [--person.name str]
+                [--person.age int] [--person.favorite_toy str]
+                """
+    )

--- a/tests/test_argparse_choice_types.py
+++ b/tests/test_argparse_choice_types.py
@@ -36,19 +36,17 @@ def test_choice_registry_argparse():
     s = Something.setup("")
     assert s.person == Adult("bob", 10)
 
-    s = Something.setup("--person.type child --person.name bob --person.favorite_toy truck", exit_on_error=False)
+    s = Something.setup("--person.type child --person.name bob --person.favorite_toy truck")
     assert s.person == Child("bob", "truck")
 
-    with pytest.raises(ArgumentError):
-        Something.setup("--person.type baby --person.name bob", exit_on_error=False)
+    with pytest.raises(SystemExit):
+        Something.setup("--person.type baby --person.name bob")
 
     with pytest.raises(ParsingError):
-        Something.setup(
-            "--person.type adult --person.name bob --person.age 10 --person.favorite_toy truck", exit_on_error=False
-        )
+        Something.setup("--person.type adult --person.name bob --person.age 10 --person.favorite_toy truck")
 
     with pytest.raises(ParsingError):
-        Something.setup("--person.name hi", exit_on_error=False)
+        Something.setup("--person.name hi")
 
 
 @dataclasses.dataclass
@@ -58,6 +56,7 @@ class Something(TestSetup):
 
 def test_choice_registry_examine_help():
 
+    # TODO: why is the default: None here?
     target = """
 usage: draccus [-h] [--config_path str] [--person.type {adult,child}]
                [--person.age int] [--person.name str]

--- a/tests/test_choice_types.py
+++ b/tests/test_choice_types.py
@@ -9,7 +9,7 @@ from draccus.choice_types import ChoiceRegistry
 
 @dataclasses.dataclass
 class Person(ChoiceRegistry):
-    name: str
+    name: str  # Person's name
 
 
 @dataclasses.dataclass

--- a/tests/test_enums.py
+++ b/tests/test_enums.py
@@ -1,15 +1,17 @@
-from builtins import TypeError
 from dataclasses import dataclass, field
 from enum import Enum, auto
+from typing import List, no_type_check
 
-from tests.testutils import *
+from draccus import ParsingError
+
+from .testutils import TestSetup, raises
 
 
 class Color(Enum):
-    blue: str = auto()
-    red: str = auto()
-    green: str = auto()
-    orange: str = auto()
+    blue: str = auto()  # type: ignore
+    red: str = auto()  # type: ignore
+    green: str = auto()  # type: ignore
+    orange: str = auto()  # type: ignore
 
 
 def test_passing_enum_to_choice():

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -99,7 +99,6 @@ class TestSetup:
     @classmethod
     def get_help_text(
         cls,
-        multiple=False,
     ) -> str:
         import contextlib
         from io import StringIO
@@ -109,8 +108,14 @@ class TestSetup:
             _ = cls.setup(
                 "--help",
             )
-        s = f.getvalue()
-        return s.strip()
+        s = f.getvalue().strip()
+
+        # python changed "optional arguments:" to "options" in 3.9
+        import re
+
+        replace_options = re.compile(r"^(optional arguments:|options:)")
+        s = replace_options.sub(s, "options:")
+        return s
 
 
 ListFormattingFunction = Callable[[List[Any]], str]

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -81,6 +81,7 @@ class TestSetup:
     def setup(
         cls: Type[Dataclass],
         arguments: Optional[str] = "",
+        exit_on_error: bool = True,
     ) -> Dataclass:
         """Basic setup for a tests.
 
@@ -93,7 +94,7 @@ class TestSetup:
         """
         if arguments is not None:
             arguments = shlex.split(arguments)  # type: ignore
-        cfg = draccus.parse(config_class=cls, args=arguments, exit_on_error=False)
+        cfg = draccus.parse(config_class=cls, args=arguments, exit_on_error=exit_on_error, prog="draccus")
         return cfg
 
     @classmethod
@@ -110,7 +111,7 @@ class TestSetup:
                 "--help",
             )
         s = f.getvalue()
-        return s
+        return s.strip()
 
 
 ListFormattingFunction = Callable[[List[Any]], str]

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -93,7 +93,7 @@ class TestSetup:
         """
         if arguments is not None:
             arguments = shlex.split(arguments)  # type: ignore
-        cfg = draccus.parse(config_class=cls, args=arguments)
+        cfg = draccus.parse(config_class=cls, args=arguments, exit_on_error=False)
         return cfg
 
     @classmethod

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -25,7 +25,7 @@ Dataclass = TypeVar("Dataclass")
 
 
 @contextmanager
-def raises(exception=ParsingError, match=None, code: int = None):
+def raises(exception=ParsingError, match=None, code: Optional[int] = None):
     with pytest.raises(exception, match=match):
         yield
 

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -81,7 +81,6 @@ class TestSetup:
     def setup(
         cls: Type[Dataclass],
         arguments: Optional[str] = "",
-        exit_on_error: bool = True,
     ) -> Dataclass:
         """Basic setup for a tests.
 
@@ -94,7 +93,7 @@ class TestSetup:
         """
         if arguments is not None:
             arguments = shlex.split(arguments)  # type: ignore
-        cfg = draccus.parse(config_class=cls, args=arguments, exit_on_error=exit_on_error, prog="draccus")
+        cfg = draccus.parse(config_class=cls, args=arguments, prog="draccus")
         return cfg
 
     @classmethod

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -113,8 +113,8 @@ class TestSetup:
         # python changed "optional arguments:" to "options" in 3.9
         import re
 
-        replace_options = re.compile(r"^(optional arguments:|options:)")
-        s = replace_options.sub(s, "options:")
+        replace_options = re.compile(r"(?m)^(optional arguments:|options:)$")
+        s = replace_options.sub("options:", s)
         return s
 
 


### PR DESCRIPTION
also fixes the help stuff

```
usage: draccus [-h] [--config_path str] [--person.type {adult,child}]
               [--person.age int] [--person.name str]
               [--person.favorite_toy str]
options:
  -h, --help            show this help message and exit
  --config_path str     Path for a config file to parse with draccus (default:
                        None)
Something:
Person ['person']:
  --person.type {adult,child}
                        Which type of Person ['person'] to use (default: None)
Adult ['person']:
  --person.name str     Person's name (default: None)
  --person.age int
Child ['person']:
  --person.name str     Person's name (default: None)
  --person.favorite_toy str
                        Child's favorite toy (default: None)
```