### PR TITLE
Pin pyyaml-include to v1.4.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 dependencies = [
     "mergedeep",
     "pyyaml",
-    "pyyaml-include",
+    "pyyaml-include==1.4.1",
     "toml",
     "typing-inspect",
 ]


### PR DESCRIPTION
Newer versions of `pyyaml-include` introduce breaking changes (namespace); pins to last "known-good" version.

Resolves #12 