### PR TITLE
Including file include from the commandline

### DIFF
--- a/draccus/argparsing.py
+++ b/draccus/argparsing.py
@@ -141,7 +141,11 @@ class ArgumentParser(Generic[T]):
         parsed_arg_values = vars(parsed_args)
 
         for key in parsed_arg_values:
-            parsed_arg_values[key] = cfgparsing.parse_string(parsed_arg_values[key])
+            parsed_value = cfgparsing.parse_string(parsed_arg_values[key])
+            if isinstance(parsed_value, str) and parsed_value.startswith("include"):
+                parsed_arg_values[key] = cfgparsing.load_config(open(parsed_value[8:], "r"))
+            else:
+                parsed_arg_values[key] = parsed_value
 
         config_path = self.config_path  # Could be NONE
 

--- a/draccus/wrappers/dataclass_wrapper.py
+++ b/draccus/wrappers/dataclass_wrapper.py
@@ -60,6 +60,9 @@ class DataclassWrapper(AggregateWrapper[Type[Dataclass]]):
 
         for child in self._children:
             if isinstance(child, AggregateWrapper):
+                # Child name will always be populated as this is done via our code inside `_wrap_field`
+                parser.add_argument("--" + child.name , type=str, required=False,
+                                    help="Config file for " + child.name)
                 child.register_actions(parser)
             elif isinstance(child, FieldWrapper):
                 child.add_action(group)

--- a/tests/test_argparse_choice_types.py
+++ b/tests/test_argparse_choice_types.py
@@ -56,14 +56,15 @@ class Something(TestSetup):
 def test_choice_registry_examine_help():
     # TODO: why is the default: None here?
     target = """
-usage: draccus [-h] [--config_path str] [--person.type {adult,child}]
-               [--person.age int] [--person.name str]
-               [--person.favorite_toy str]
+    usage: draccus [-h] [--config_path str] [--person str]
+               [--person.type {adult,child}] [--person.age int]
+               [--person.name str] [--person.favorite_toy str]
 
 options:
   -h, --help            show this help message and exit
   --config_path str     Path for a config file to parse with draccus (default:
                         None)
+  --person str          Config file for person (default: None)
 
 Something:
 
@@ -83,5 +84,5 @@ Child ['person']:
   --person.favorite_toy str
                         Child's favorite toy (default: None)
 """
-
+    print(Something.get_help_text().strip())
     assert Something.get_help_text().strip() == target.strip()

--- a/tests/test_argparse_choice_types_plugin.py
+++ b/tests/test_argparse_choice_types_plugin.py
@@ -50,7 +50,7 @@ def test_choice_registry_examine_help():
 
     # TODO: why is the default: None here?
     target = """
-usage: draccus [-h] [--config_path str] [--model.type {mlp,gpt}]
+usage: draccus [-h] [--config_path str] [--model str] [--model.type {mlp,gpt}]
                [--model.hidden_size int] [--model.layers int]
                [--model.attn_pdrop float]
 
@@ -58,6 +58,7 @@ options:
   -h, --help            show this help message and exit
   --config_path str     Path for a config file to parse with draccus (default:
                         None)
+  --model str           Config file for model (default: None)
 
 test_choice_registry_examine_help.<locals>.Something:
 
@@ -77,5 +78,5 @@ GptConfig ['model']:
   --model.layers int
   --model.attn_pdrop float
 """
-
+    print(Something.get_help_text())
     assert Something.get_help_text().strip() == target.strip()

--- a/tests/test_yaml_inclusion_cli.py
+++ b/tests/test_yaml_inclusion_cli.py
@@ -1,0 +1,77 @@
+import tempfile
+from enum import Enum, auto
+from pathlib import Path
+
+from tests.conftest import Optimizers
+
+
+class Color(Enum):
+    blue: str = auto()  # type: ignore
+    red: str = auto()  # type: ignore
+
+
+def test_load_hyperparameters_with_include(HyperParameters):
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmpdir = Path(tmpdir)
+
+        config_path = tmpdir / "config.yaml"
+        config_path.write_text(
+            """
+age_group: !include ./age_group.yaml
+batch_size: 1234
+            """
+        )
+
+        age_group_path = tmpdir / "age_group.yaml"
+        age_group_path.write_text(
+            """
+name: age_group
+num_units: 16
+"""
+        )
+
+        age_group_path_cli = tmpdir / "age_group_cli.yaml"
+        age_group_path_cli.write_text(
+            """
+name: age_group_cli
+num_units: 16
+"""
+        )
+
+
+        config = HyperParameters.setup(f"--config_path {config_path} "
+                                       f"--age_group 'include {age_group_path_cli}' "
+                                       f"--age_group.num_units 32")
+
+        assert config.age_group.name == "age_group_cli"
+        assert config.age_group.num_units == 32
+
+
+def test_merge_include_hyperparameters(HyperParameters):
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmpdir = Path(tmpdir)
+
+        config_path = tmpdir / "config.yaml"
+        config_path.write_text(
+            """
+age_group: 
+  name: age_group_1
+  num_units: 16
+batch_size: 1234
+            """
+        )
+
+        age_group_path_cli = tmpdir / "age_group_cli.yaml"
+        age_group_path_cli.write_text(
+            """
+name: age_group_cli
+num_units: 678
+"""
+        )
+
+        config = HyperParameters.setup(f"--config_path {config_path} "
+                                       f"--age_group 'include {age_group_path_cli}' ")
+
+        assert config.age_group.name == "age_group_cli"
+        assert config.age_group.num_units == 678
+


### PR DESCRIPTION
Only pitfall is that if an input argument has `include` as the starting keywords. Probably can make it something like `!include` instead of include.

1. Look into if it's somehow possible to use a custom datatype inside `dataclass_wrapper` and detect it while arparsing.
2. Testing for various different cases.
    a. Nested includes in config files
    b. include plus command line:  `python dracus.py --config_path config.yaml --data "include data.yaml" --data.data_path "path_not_found"`