### PR TITLE
Onboarding nits

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ class TrainConfig:
 @draccus.wrap()
 def main(cfg: TrainConfig):
     print(f"Training {cfg.exp_name} with {cfg.workers} workers...")
+
+if __name__ == "__main__":
+    main()
 ```
 
 The arguments can then be specified using command-line arguments, a `yaml` configuration file, or both.

--- a/draccus/__init__.py
+++ b/draccus/__init__.py
@@ -1,6 +1,5 @@
 __version__ = "0.8.0"
 
-from . import utils, wrappers
 from .argparsing import parse, wrap
 from .cfgparsing import dump, load
 from .choice_types import CHOICE_TYPE_KEY, ChoiceRegistry, ChoiceType, PluginRegistry
@@ -12,3 +11,23 @@ from .utils import ParsingError
 
 get_config_type = Options.get_config_type
 set_config_type = Options.set_config_type
+
+__all__ = [
+    "CHOICE_TYPE_KEY",
+    "ChoiceRegistry",
+    "ChoiceType",
+    "ConfigType",
+    "Options",
+    "ParsingError",
+    "PluginRegistry",
+    "config_type",
+    "decode",
+    "dump",
+    "encode",
+    "field",
+    "get_config_type",
+    "load",
+    "parse",
+    "set_config_type",
+    "wrap",
+]


### PR DESCRIPTION
Two minor suggestions:

* Make README.md first example run without edits
* Add an `__all__` to `__init__.py` because without it it [looks like](https://typing.python.org/en/latest/spec/distributing.html#library-interface-public-and-private-symbols) all imported symbols are by default considered private. (Pyright was complaining to me)