### PR TITLE
Fix `license` field to be PEP 621 compliant

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
 description = "A slightly opinionated framework for simple dataclass-based configurations based on Pyrallis."
 readme = "README.md"
 requires-python = ">=3.9"
-license = "MIT"
+license = { text = "MIT" }
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Operating System :: OS Independent",


### PR DESCRIPTION
This PR updates the `license` field in `pyproject.toml` to be compliant with [PEP 621](https://peps.python.org/pep-0621/#license), replacing:

```toml
license = "MIT"
```

with:

```toml
license = { text = "MIT" }
```

This resolves build-time schema validation errors under recent versions of `setuptools`, as well as with tools like `uv`, `hatch`, and `poetry`.

Let me know if you'd prefer the license to be declared via a `file` instead.