### PR TITLE
Ensure primitives are type-cast for encode

### DIFF
--- a/draccus/parsers/encoding.py
+++ b/draccus/parsers/encoding.py
@@ -204,7 +204,10 @@ def encode_enum(obj: Enum, declared_type: Optional[Type] = None) -> str:
 
 
 for t in [str, float, int, bool, bytes]:
-    encode.register(t, lambda x, _=None: x)
+    def cvt(x, _=None, t=t):
+        return t(x)
+    # subclass enums
+    encode.register(t, cvt, include_subclasses=True)
 
 
 @encode.register(list)


### PR DESCRIPTION
This ensure primitive-inheriting types are cast to primitives, resolving issue #48 