### PR TITLE
Add PluginRegistryWithClassNameFallback to resolve fully-qualified class names

### DIFF
--- a/draccus/__init__.py
+++ b/draccus/__init__.py
@@ -13,6 +13,7 @@ from .choice_types import (
     ChoiceType,
     PluginRegistry,
     PluginRegistryWithClassNameFallback,
+    QNamePluginRegistry,
 )
 from .fields import field
 from .options import ConfigType, Options, config_type
@@ -32,6 +33,7 @@ __all__ = [
     "ParsingError",
     "PluginRegistry",
     "PluginRegistryWithClassNameFallback",
+    "QNamePluginRegistry",
     "config_type",
     "decode",
     "dump",

--- a/draccus/__init__.py
+++ b/draccus/__init__.py
@@ -7,7 +7,13 @@ __version__ = "0.8.0"
 
 from .argparsing import parse, wrap
 from .cfgparsing import dump, load, loads
-from .choice_types import CHOICE_TYPE_KEY, ChoiceRegistry, ChoiceType, PluginRegistry
+from .choice_types import (
+    CHOICE_TYPE_KEY,
+    ChoiceRegistry,
+    ChoiceType,
+    PluginRegistry,
+    PluginRegistryWithClassNameFallback,
+)
 from .fields import field
 from .options import ConfigType, Options, config_type
 from .parsers.decoding import decode
@@ -25,6 +31,7 @@ __all__ = [
     "Options",
     "ParsingError",
     "PluginRegistry",
+    "PluginRegistryWithClassNameFallback",
     "config_type",
     "decode",
     "dump",

--- a/draccus/__init__.py
+++ b/draccus/__init__.py
@@ -12,7 +12,6 @@ from .choice_types import (
     ChoiceRegistry,
     ChoiceType,
     PluginRegistry,
-    PluginRegistryWithClassNameFallback,
     QNamePluginRegistry,
 )
 from .fields import field
@@ -32,7 +31,6 @@ __all__ = [
     "Options",
     "ParsingError",
     "PluginRegistry",
-    "PluginRegistryWithClassNameFallback",
     "QNamePluginRegistry",
     "config_type",
     "decode",

--- a/draccus/choice_types.py
+++ b/draccus/choice_types.py
@@ -246,16 +246,31 @@ class QNamePluginRegistry(PluginRegistry):
 
     @classmethod
     def _resolve_fully_qualified_name(cls, name: str) -> Any:
-        module_name, _, qualname = name.rpartition(".")
-        if not module_name:
+        name_parts = name.split(".")
+        if len(name_parts) < 2:
             raise KeyError(name)
-        module = importlib.import_module(module_name)
+
+        module: Optional[Any] = None
+        qualname_parts: list[str] = []
+        for i in range(len(name_parts) - 1, 0, -1):
+            module_name = ".".join(name_parts[:i])
+            try:
+                module = importlib.import_module(module_name)
+            except ImportError:
+                continue
+            qualname_parts = name_parts[i:]
+            break
+
+        if module is None or not qualname_parts:
+            raise KeyError(name)
+
         obj: Any = module
-        for attr in qualname.split("."):
+        for attr in qualname_parts:
             try:
                 obj = getattr(obj, attr)
             except AttributeError as exc:
                 raise KeyError(name) from exc
+
         if not isinstance(obj, type) or not issubclass(obj, cls):
             raise KeyError(name)
         return obj

--- a/draccus/choice_types.py
+++ b/draccus/choice_types.py
@@ -260,6 +260,3 @@ class QNamePluginRegistry(PluginRegistry):
             raise KeyError(name)
         return obj
 
-
-# Backwards compatibility alias.
-PluginRegistryWithClassNameFallback = QNamePluginRegistry

--- a/draccus/choice_types.py
+++ b/draccus/choice_types.py
@@ -209,3 +209,44 @@ class PluginRegistry(ChoiceRegistryBase):
             # registration should happen in the initialization of the package, so importing is sufficient
 
         cls._did_discover_packages = True
+
+
+class PluginRegistryWithClassNameFallback(PluginRegistry):
+    """
+    A PluginRegistry that falls back to resolving fully qualified class names.
+
+    This is useful when you want to encode/decode choices using a full class path
+    in addition to registered short names.
+    """
+
+    @classmethod
+    def get_choice_class(cls, name: str) -> Any:
+        cls._discover_packages()
+        if name in cls._choice_registry:
+            return cls._choice_registry[name]
+        resolved = cls._resolve_fully_qualified_name(name)
+        cls._choice_registry[name] = resolved
+        return resolved
+
+    @classmethod
+    def get_choice_name(cls, subcls: Type) -> str:
+        try:
+            return super().get_choice_name(subcls)
+        except ValueError:
+            return f"{subcls.__module__}.{subcls.__qualname__}"
+
+    @classmethod
+    def _resolve_fully_qualified_name(cls, name: str) -> Any:
+        module_name, _, qualname = name.rpartition(".")
+        if not module_name:
+            raise KeyError(name)
+        module = importlib.import_module(module_name)
+        obj: Any = module
+        for attr in qualname.split("."):
+            try:
+                obj = getattr(obj, attr)
+            except AttributeError as exc:
+                raise KeyError(name) from exc
+        if not isinstance(obj, type) or not issubclass(obj, cls):
+            raise KeyError(name)
+        return obj

--- a/draccus/choice_types.py
+++ b/draccus/choice_types.py
@@ -173,10 +173,10 @@ class PluginRegistry(ChoiceRegistryBase):
         super().__init_subclass__(**kwargs)
         if not hasattr(cls, "_choice_registry"):
             cls._choice_registry = {}
-        if not hasattr(cls, "discover_packages_path"):
-            if discover_packages_path is None:
-                raise ValueError("discover_packages_path must be specified in the class or constructor")
+        if discover_packages_path is not None:
             cls.discover_packages_path = discover_packages_path
+        elif not hasattr(cls, "discover_packages_path"):
+            raise ValueError("discover_packages_path must be specified in the class or constructor")
         cls._did_discover_packages = False
 
     @classmethod
@@ -211,13 +211,20 @@ class PluginRegistry(ChoiceRegistryBase):
         cls._did_discover_packages = True
 
 
-class PluginRegistryWithClassNameFallback(PluginRegistry):
+class QNamePluginRegistry(PluginRegistry):
     """
     A PluginRegistry that falls back to resolving fully qualified class names.
 
     This is useful when you want to encode/decode choices using a full class path
     in addition to registered short names.
     """
+
+    discover_packages_path: ClassVar[str] = "__qname_plugin_registry_base__"
+
+    def __init_subclass__(cls, discover_packages_path: Optional[str] = None, **kwargs):
+        super().__init_subclass__(discover_packages_path=discover_packages_path, **kwargs)
+        if cls is not QNamePluginRegistry and cls.discover_packages_path == QNamePluginRegistry.discover_packages_path:
+            raise ValueError("discover_packages_path must be specified in the class or constructor")
 
     @classmethod
     def get_choice_class(cls, name: str) -> Any:
@@ -230,6 +237,8 @@ class PluginRegistryWithClassNameFallback(PluginRegistry):
 
     @classmethod
     def get_choice_name(cls, subcls: Type) -> str:
+        if subcls is cls and QNamePluginRegistry in cls.__bases__:
+            raise ValueError(f"Cannot find choice name for {subcls}")
         try:
             return super().get_choice_name(subcls)
         except ValueError:
@@ -250,3 +259,7 @@ class PluginRegistryWithClassNameFallback(PluginRegistry):
         if not isinstance(obj, type) or not issubclass(obj, cls):
             raise KeyError(name)
         return obj
+
+
+# Backwards compatibility alias.
+PluginRegistryWithClassNameFallback = QNamePluginRegistry

--- a/draccus/utils.py
+++ b/draccus/utils.py
@@ -381,13 +381,13 @@ def has_generic_arg(args):
 def is_choice_type(cls: Any) -> bool:
     """
     Returns True if
-    1) cls is a ChoiceRegistry or PluginRegistry, or a *direct* subclass of one of those
+    1) cls is a ChoiceRegistry/PluginRegistry/QNamePluginRegistry, or a *direct* subclass of one of those
     OR
     2) cls structurally matches the ChoiceType protocol, but none of its parents do
     """
-    from draccus.choice_types import ChoiceRegistry, ChoiceType, PluginRegistry
+    from draccus.choice_types import ChoiceRegistry, ChoiceType, PluginRegistry, QNamePluginRegistry
 
-    CHOICE_BASES = (ChoiceRegistry, PluginRegistry, ChoiceType)
+    CHOICE_BASES = (ChoiceRegistry, PluginRegistry, QNamePluginRegistry, ChoiceType)
 
     # Skip if not a proper class
     if not isinstance(cls, type):

--- a/tests/test_choice_types.py
+++ b/tests/test_choice_types.py
@@ -89,3 +89,21 @@ def test_qname_plugin_registry_encode_fallback():
         "layers": 3,
         "width": 16,
     }
+
+
+class NestedQNameModels:
+    @dataclasses.dataclass
+    class UnregisteredNestedQNameModelConfig(QNameModelConfig):
+        depth: int
+
+
+def test_qname_plugin_registry_nested_qualname_decode_fallback():
+    nested_qname = (
+        f"{NestedQNameModels.UnregisteredNestedQNameModelConfig.__module__}."
+        f"{NestedQNameModels.UnregisteredNestedQNameModelConfig.__qualname__}"
+    )
+
+    decoded = draccus.decode(QNameModelConfig, {"type": nested_qname, "layers": 4, "depth": 2})
+
+    assert decoded == NestedQNameModels.UnregisteredNestedQNameModelConfig(layers=4, depth=2)
+

--- a/tests/test_choice_types.py
+++ b/tests/test_choice_types.py
@@ -7,7 +7,7 @@ import pytest
 
 import draccus
 from draccus import ParsingError
-from draccus.choice_types import ChoiceRegistry
+from draccus.choice_types import ChoiceRegistry, QNamePluginRegistry
 from draccus.utils import DecodingError
 
 
@@ -60,3 +60,32 @@ def test_is_choicetype():
     assert draccus.utils.is_choice_type(Person)
     assert not draccus.utils.is_choice_type(Adult)
     assert not draccus.utils.is_choice_type(Child)
+
+
+@dataclasses.dataclass
+class QNameModelConfig(QNamePluginRegistry, discover_packages_path="tests.draccus_choice_plugins"):
+    layers: int
+
+
+@dataclasses.dataclass
+class UnregisteredQNameModelConfig(QNameModelConfig):
+    width: int
+
+
+def test_qname_plugin_registry_decode_fallback():
+    qname = f"{UnregisteredQNameModelConfig.__module__}.{UnregisteredQNameModelConfig.__qualname__}"
+
+    decoded = draccus.decode(QNameModelConfig, {"type": qname, "layers": 2, "width": 8})
+
+    assert decoded == UnregisteredQNameModelConfig(layers=2, width=8)
+    assert QNameModelConfig.get_choice_class(qname) is UnregisteredQNameModelConfig
+
+
+def test_qname_plugin_registry_encode_fallback():
+    encoded = draccus.encode(UnregisteredQNameModelConfig(layers=3, width=16), QNameModelConfig)
+
+    assert encoded == {
+        "type": f"{UnregisteredQNameModelConfig.__module__}.{UnregisteredQNameModelConfig.__qualname__}",
+        "layers": 3,
+        "width": 16,
+    }


### PR DESCRIPTION
### Motivation
- Allow choice types to be referenced by fully-qualified class names when a short registered name is not available for encode/decode.
- Support scenarios where plugins may not be registered in the registry but are still importable by module path.
- Provide a stable fallback name for unregistered classes using their `module.qualname`.
- Cache resolved fully-qualified names to avoid repeated imports and lookups.

### Description
- Added `PluginRegistryWithClassNameFallback` as a subclass of `PluginRegistry` to provide the fallback behavior.
- Implemented `get_choice_class` to call `_discover_packages()`, check the registry, resolve a fully-qualified name via `_resolve_fully_qualified_name`, and cache the resolved class.
- Implemented `get_choice_name` to return the registered name or fall back to `"{module}.{qualname}"` when the class is not registered.
- Implemented `_resolve_fully_qualified_name` using `importlib.import_module` and attribute traversal, including a subclass validation, and exported the new class in `__init__.py`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695eeff8e2f48331a39d7b7ac8eaf5e4)