### PR TITLE
Fix encoding crash with `from __future__ import annotations`

### DIFF
--- a/draccus/parsers/encoding.py
+++ b/draccus/parsers/encoding.py
@@ -142,11 +142,16 @@ def encode_dataclass(obj: Any, declared_type: Optional[Type] = None):
             type_args = typing.get_args(declared_type)
             type_map = dict(zip(type_vars, type_args))
 
+    # Resolve string annotations from `from __future__ import annotations`
+    # to real types, mirroring what decode_dataclass does (see PR #23).
+    origin = typing.get_origin(declared_type) or declared_type if declared_type is not None else type(obj)
+    hints = typing.get_type_hints(origin) if is_dataclass(origin) else {}
+
     for field in fields(obj):
         value = getattr(obj, field.name)
         try:
             # If we have a type map, use it to resolve the field's type
-            field_type = field.type
+            field_type = hints.get(field.name, field.type)
             if type_map and hasattr(field_type, "__parameters__"):
                 field_type = field_type[tuple(type_map.get(p, p) for p in field_type.__parameters__)]
             d[field.name] = encode(value, field_type)

--- a/tests/test_future_annotations.py
+++ b/tests/test_future_annotations.py
@@ -30,3 +30,21 @@ def test_future_annotations():
 def test_nested_future_annotations():
     c: C = draccus.parse(config_class=C, args="")
     assert c.a.b == 1
+
+
+def test_encode_future_annotations():
+    """Encoding a dataclass defined with `from __future__ import annotations` should work."""
+    from draccus.parsers.encoding import encode
+
+    a = A(b=42)
+    result = encode(a)
+    assert result == {"b": 42}
+
+
+def test_encode_nested_future_annotations():
+    """Encoding nested dataclasses with future annotations should work."""
+    from draccus.parsers.encoding import encode
+
+    c = C(a=A(b=7), elems=[A(b=1), A(b=2)])
+    result = encode(c)
+    assert result == {"a": {"b": 7}, "elems": [{"b": 1}, {"b": 2}]}


### PR DESCRIPTION

resolves https://github.com/marin-community/draccus/issues/61

## Summary

`encode_dataclass` uses `field.type` directly, which returns string annotations (e.g. `"int"`) when the dataclass module uses `from __future__ import annotations`. These strings get passed to `dispatch()` in `registry_utils.py`, which tries to cache them in a `WeakKeyDictionary` — but strings aren't weakref-able, causing:

```
TypeError: cannot create weak reference to 'str' object
```

This was already fixed for the **decoding** path in PR #23 by using `typing.get_type_hints()` to resolve annotations. PR #36 later added `declared_type` support to encoding but used raw `field.type`, reintroducing the same bug on the encoding side.

## Fix

Resolve annotations via `typing.get_type_hints()` in `encode_dataclass`, mirroring the existing approach in `decode_dataclass` (line 141).

## Test plan

- Added `test_encode_future_annotations` and `test_encode_nested_future_annotations` to `tests/test_future_annotations.py`
- Both fail on `main`, both pass with this fix
- Existing tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)