### PR TITLE
fix: resolve future annotations before encoding dataclasses

### DIFF
--- a/draccus/parsers/encoding.py
+++ b/draccus/parsers/encoding.py
@@ -142,11 +142,18 @@ def encode_dataclass(obj: Any, declared_type: Optional[Type] = None):
             type_args = typing.get_args(declared_type)
             type_map = dict(zip(type_vars, type_args))
 
+    resolved_type_hints: Dict[str, Any] = {}
+    if any(isinstance(field.type, str) for field in fields(obj)):
+        try:
+            resolved_type_hints = typing.get_type_hints(type(obj), include_extras=True)
+        except Exception:
+            resolved_type_hints = {}
+
     for field in fields(obj):
         value = getattr(obj, field.name)
         try:
             # If we have a type map, use it to resolve the field's type
-            field_type = field.type
+            field_type = resolved_type_hints.get(field.name, field.type)
             if type_map and hasattr(field_type, "__parameters__"):
                 field_type = field_type[tuple(type_map.get(p, p) for p in field_type.__parameters__)]
             d[field.name] = encode(value, field_type)

--- a/tests/test_future_annotations.py
+++ b/tests/test_future_annotations.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from io import StringIO
 from typing import List
 
 import draccus
@@ -22,6 +23,11 @@ class C:
     elems: List[A] = field(default_factory=list)
 
 
+@dataclass(frozen=True)
+class FutureDumpConfig:
+    name: str = "train"
+
+
 def test_future_annotations():
     an_a: A = draccus.parse(config_class=A, args="")
     assert an_a.b == 1
@@ -30,3 +36,11 @@ def test_future_annotations():
 def test_nested_future_annotations():
     c: C = draccus.parse(config_class=C, args="")
     assert c.a.b == 1
+
+
+def test_dump_future_annotation_string_field():
+    stream = StringIO()
+
+    draccus.dump(FutureDumpConfig(), stream)
+
+    assert "name: train" in stream.getvalue()


### PR DESCRIPTION
- resolve stringified dataclass field annotations before encoding fields
- prevent `draccus.dump()` from passing bare annotation strings into the encoder dispatch cache
- add a regression test for dumping a future-annotations dataclass with a `str` field