### PR TITLE
Add PyPI publish workflow and bump version to 0.11.6

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,44 @@
+name: publish
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v6
+      - name: Verify tag matches package version
+        run: |
+          version="$(grep -m1 -E '^version *= *"' pyproject.toml | sed -E 's/^version *= *"([^"]+)".*/\1/')"
+          tag="${GITHUB_REF_NAME#v}"
+          if [ "$version" != "$tag" ]; then
+            echo "::error::tag ${GITHUB_REF_NAME} does not match pyproject version ${version}"
+            exit 1
+          fi
+      - name: Build sdist and wheel
+        run: uv build
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    # Trusted Publishing: the OIDC token minted here is exchanged for a
+    # short-lived PyPI upload token, so no API token is stored in the repo.
+    environment:
+      name: pypi
+      url: https://pypi.org/p/draccus
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - uses: pypa/gh-action-pypi-publish@release/v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "draccus"
-version = "0.11.5"
+version = "0.11.6"
 authors = [
   {name = "David Hall", email = "dlwh@cs.stanford.edu"},
   {name = "Siddharth Karamcheti", email = "skaramcheti@cs.stanford.edu"},

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.9"
 resolution-markers = [
     "python_full_version >= '3.10'",
@@ -105,7 +105,7 @@ wheels = [
 
 [[package]]
 name = "draccus"
-version = "0.11.5"
+version = "0.11.6"
 source = { editable = "." }
 dependencies = [
     { name = "mergedeep" },


### PR DESCRIPTION
Cuts 0.11.6 to release the fix from #64 — `draccus.dump` crashing with
`TypeError: cannot create weak reference to 'str' object` on dataclasses whose
modules use `from __future__ import annotations`, where `field.type` is a
stringized annotation that the encoder fed straight into a `WeakKeyDictionary`.

Also adds a tag-triggered release workflow so releases are reproducible instead
of hand-published. Pushing a `v*` tag builds the sdist/wheel with uv and
publishes to PyPI via Trusted Publishing (OIDC) — no long-lived token stored in
the repo. The build job first verifies the tag matches the `pyproject.toml`
version.

Before the first automated publish succeeds, a draccus PyPI maintainer must add
a trusted publisher at https://pypi.org/manage/project/draccus/settings/publishing/:

- Owner: `marin-community`
- Repository: `draccus`
- Workflow: `publish.yml`
- Environment: `pypi`

Once merged and configured, cut the release by tagging:

    git tag v0.11.6 && git push origin v0.11.6
